### PR TITLE
[.travis.yml] drop yarn install for old container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ node_js:
   - '8'
   - '6'
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH="$HOME/.yarn/bin:$PATH"
-
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: travisにyarnを入れるコードを削除


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: 現行のtravis ciはyarnがあらかじめインストールされており、yarn.lockファイルの存在を検知してnpm installの代わりにyarn installが実行される仕様のため

参考: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Travis-CI-supports-yarn


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: .tavis.ymlから該当の設定を削除
