### PR TITLE
add --list option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,7 @@ const cli = meow(
   Options
   -a, --add         Create new template file
   -o, --overwrite   Overwrite by template
+  -l, --list        show template file list
 
   Example
   $ touch-alt .editorconfig
@@ -28,6 +29,11 @@ const cli = meow(
         alias: 'o',
         type: 'boolean',
         default: false
+      },
+      list: {
+        alias: 'l',
+        type: 'boolean',
+        default: false
       }
     }
   }
@@ -35,14 +41,11 @@ const cli = meow(
 
 updateNotifier({ pkg: cli.pkg }).notify()
 
-const [input] = cli.input
-
-if (!input) {
-  process.exit(0)
-}
-
 try {
-  fn(input, cli.flags)
+  const output = fn(cli.input[0], cli.flags)
+  if (output) {
+    console.log(output)
+  }
 } catch (err) {
   if (err.name === 'CpyError') {
     console.log(err.message)

--- a/index.js
+++ b/index.js
@@ -7,13 +7,26 @@ const makeDir = require('make-dir')
 const pathExists = require('path-exists')
 
 module.exports = (input, opts) => {
+  opts = Object.assign({ add: false, overwrite: false, list: false }, opts)
+
+  const configPath = opts.dirPath || path.join(os.homedir(), '.touch-alt')
+
+  if (input === undefined) {
+    if (opts.list) {
+      if (!pathExists.sync(configPath)) {
+        return 'no template files'
+      }
+      const files = fs.readdirSync(configPath)
+      if (files.length === 0) {
+        return 'no template files'
+      }
+      return files.join('\n')
+    }
+    return
+  }
   if (typeof input !== 'string') {
     throw new TypeError(`Expected a string, got ${typeof input}`)
   }
-
-  opts = Object.assign({ add: false, overwrite: false }, opts)
-
-  const configPath = opts.dirPath || path.join(os.homedir(), '.touch-alt')
 
   if (!pathExists.sync(configPath)) {
     makeDir.sync(configPath)

--- a/test.js
+++ b/test.js
@@ -21,6 +21,11 @@ test.afterEach.always(t => {
   Object.keys(t.context).forEach(p => del.sync(t.context[p]))
 })
 
+test('no input and no flags', t => {
+  const result = fn()
+  t.is(result, undefined)
+})
+
 test('run', t => {
   const { targetPath, targetFilePath, output } = t.context
   fs.mkdirSync(targetPath)
@@ -62,6 +67,29 @@ test('--overwrite=false', t => {
   fs.writeFileSync(output, 'unicorn')
   fn(output, { dirPath: targetPath, overwrite: false })
   t.is(fs.readFileSync(output, 'utf-8'), 'unicorn')
+})
+
+test('--list with no target directory', t => {
+  const { targetPath } = t.context
+  const result = fn(undefined, { dirPath: targetPath, list: true })
+  t.is(result, 'no template files')
+})
+
+test('--list with empty targets', t => {
+  const { targetPath } = t.context
+  fs.mkdirSync(targetPath)
+  const result = fn(undefined, { dirPath: targetPath, list: true })
+  t.is(result, 'no template files')
+})
+
+test('--list with targets', t => {
+  const { targetPath, targetFilePath } = t.context
+  fs.mkdirSync(targetPath)
+  fs.writeFileSync(targetFilePath, 'foo', 'utf-8')
+  fs.writeFileSync(`${targetFilePath}2`, 'bar', 'utf-8')
+  const files = fs.readdirSync(targetPath)
+  const result = fn(undefined, { dirPath: targetPath, list: true })
+  t.is(result, `${files[0]}\n${files[1]}`)
 })
 
 test('throw err', t => {


### PR DESCRIPTION
**What**:
`--list` オプションを追加しました。 https://github.com/akameco/touch-alt/issues/4 の対応。 

**Why**:
現状どのようなテンプレートファイルがあるか知る機能があれば便利だから。

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:
- 結果を標準出力に出す必要があったので、 `index.js`  の関数は文字列を返し、 `cli.js` 側は返された文字列を出力するように変更しました。( `index.js` 側で直接出力するよりも、テストがしやすくなるので)
- テストのカバレッジ100%です。

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
